### PR TITLE
add -it option to docker command to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ refreshing chanes automaticly as you make them. All you need to do is to mount
 your page in a volume under `/usr/src/app` like this:
 
 ```
-$ docker run --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
+$ docker run --rm -it -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
 ```
 
 Remember to add all the gems to your `_config.yml` file in order to get all the


### PR DESCRIPTION
Hi,

I added the ```-it``` option to the example you provide in the readme. Without that it's not possible to stop jekyll with the ```ctrl-c``` command, you have to stop manually your container with ```docker stop```

Thanks