### PR TITLE
update github-pages gem version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM starefossen/ruby-node:2-4
 
-ENV GITHUB_GEM_VERSION 111
+ENV GITHUB_GEM_VERSION 112
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
When merged this pull request:
* will update the github pages gem version to the latest release as of today which is v112
https://github.com/github/pages-gem/releases