### PR TITLE
Update to github-pages v177

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM starefossen/ruby-node:2-6-alpine
 
-ENV GITHUB_GEM_VERSION 172
+ENV GITHUB_GEM_VERSION 177
 ENV JSON_GEM_VERSION 1.8.6
 
 RUN apk --update add --virtual build_deps \


### PR DESCRIPTION
Thanks for the Docker image!  Makes total sense to have a standard image to run for GitHub Pages repos.  Very helpful.

I noticed that [the current version is 177](https://rubygems.org/gems/github-pages/versions/172), so I thought I'd make this PR.  I haven't done much testing, so this is a bit of a "drive-by PR".  Please let me know if you need any help with that.

Related: there's a handy [RSS feed of github-pages gem versions here](https://rubygems.org/gems/github-pages/versions.atom).