### PR TITLE
Adds the `i` to `docker run -it ...` in the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ refreshing changes automatically as you make them. All you need to do is to moun
 your page in a volume under `/usr/src/app` like this:
 
 ```
-$ docker run -t --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
+$ docker run -it --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
 ```
 
 Your Jekyll page will be available on `http://localhost:4000`.


### PR DESCRIPTION
Without this `ctrl-c` leaves the containerized process running in the background so you won't be able to start jekyll again because the old one will be detatched but still hanging on to `:4000`.