### PR TITLE
Updated README.md with Docker Compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ services:
     tty: true
 ```
 
-Then start the container with `docker-compose run --rm -p 4000:4000 jekyll`.
+Then start the container with `docker-compose run --rm --service-ports jekyll`.
 
 ## Slow filesystem issues in Docker for Mac
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ services:
     tty: true
 ```
 
-Then start the container with `docker-compose run --rm jekyll`.
+Then start the container with `docker-compose run --rm -p 4000:4000 jekyll`.
 
 ## Slow filesystem issues in Docker for Mac
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ $ docker run \
   -p "4000:4000" starefossen/github-pages
 ```
 
+## Docker compose
+
+If you want to use Docker Compose instead, you can move a lot of the options into a `docker-compose.yml` at the root of your project:
+
+```
+version: '3'
+services:
+  jekyll:
+    image: starefossen/github-pages
+    environment:
+      - "JEKYLL_GITHUB_TOKEN:${JEKYLL_GITHUB_TOKEN}"
+    ports:
+      - "4000"
+    volumes:
+      - ./:/usr/src/app
+    tty: true
+```
+
+Then start the container with `docker-compose run --rm jekyll`.
+
 ## Slow filesystem issues in Docker for Mac
 
 When running this image in [Docker for Mac](https://docs.docker.com/docker-for-mac/) you might experience slow page generation times. This is due to some limitations in the Docker for Mac filesystem integration. Changing the volume configuration to `-v "$PWD":/usr/src/app:delegated` will massively improve the page generation time, at the cost of delaying the generated files showing up in your host system slightly. In case you don't even need the generated pages on your host system, you can also exclude the `_site/` folder completely from being mounted by adding a container-only volume: `-v site:/usr/src/app/_site`.


### PR DESCRIPTION
Using Docker Compose has the drawback of requiring a file in the root of your Jekyll project. But on the other hand it makes the command line for running the container much easier and let other developers discover the easy way to test your site locally.